### PR TITLE
Start migrating to Vue 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "driver.js": "0.9.8",
     "dropzone": "5.7.2",
     "echarts": "4.8.0",
-    "element-ui": "2.15.6",
+    "element-plus": "^2.6.1",
     "file-saver": "2.0.2",
     "fuse.js": "6.4.1",
     "js-cookie": "2.2.1",
@@ -68,27 +68,28 @@
     "sass-resources-loader": "^2.0.3",
     "screenfull": "5.0.2",
     "viser-vue": "^2.4.8",
-    "vue": "2.6.11",
+    "vue": "^3.2.47",
     "vue-codemirror": "^4.0.6",
     "vue-count-to": "1.0.13",
     "vue-cropper": "^0.5.5",
     "vue-particles": "^1.0.9",
-    "vue-router": "3.4.7",
+    "vue-router": "^4.2.5",
     "vuedraggable": "2.24.0",
-    "vuex": "3.5.1",
+    "vuex": "^4.1.0",
     "webpack-bundle-analyzer": "^3.8.0",
-    "xlsx": "0.16.5"
+    "xlsx": "0.16.5",
+    "mitt": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.11.1",
     "@babel/register": "^7.10.5",
     "@babel/runtime": "^7.12.1",
     "@vue/babel-preset-app": "^4.5.7",
-    "@vue/cli-plugin-babel": "4.4.6",
-    "@vue/cli-plugin-eslint": "^4.4.6",
-    "@vue/cli-plugin-unit-jest": "4.4.6",
-    "@vue/cli-service": "^4.5.13",
-    "@vue/test-utils": "1.0.3",
+    "@vue/cli-plugin-babel": "^5.0.8",
+    "@vue/cli-plugin-eslint": "^5.0.8",
+    "@vue/cli-plugin-unit-jest": "^5.0.8",
+    "@vue/cli-service": "^5.0.8",
+    "@vue/test-utils": "^2.2.6",
     "autoprefixer": "^9.8.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
@@ -100,7 +101,7 @@
     "compression-webpack-plugin": "^4.0.0",
     "connect": "3.7.0",
     "eslint": "7.6.0",
-    "eslint-plugin-vue": "6.2.2",
+    "eslint-plugin-vue": "^7.20.0",
     "html-webpack-plugin": "4.3.0",
     "husky": "4.2.5",
     "lint-staged": "10.2.11",
@@ -114,8 +115,8 @@
     "serve-static": "^1.14.1",
     "svg-sprite-loader": "^5.0.0",
     "svgo": "1.3.2",
-    "vue-loader": "^15.9.8",
-    "vue-template-compiler": "2.6.11"
+    "vue-loader": "^17.2.2",
+    "@vue/compiler-sfc": "^3.2.47"
   },
   "engines": {
     "node": ">=8.9",
@@ -127,7 +128,7 @@
   ],
   "pnpm": {
     "overrides": {
-      "vue-loader": "^15.9.8"
+      "vue-loader": "^17.2.2"
     }
   }
 }

--- a/src/components/ImageCropper/index.vue
+++ b/src/components/ImageCropper/index.vue
@@ -248,7 +248,7 @@ export default {
       // 浏览器是否支持该控件
       isSupported,
       // 浏览器是否支持触屏事件
-      isSupportTouch: document.hasOwnProperty('ontouchstart'),
+      isSupportTouch: Object.prototype.hasOwnProperty.call(document, 'ontouchstart'),
       // 步骤
       step: 1, // 1选择文件 2剪裁 3上传
       // 上传状态及进度

--- a/src/components/Upload/SingleImage.vue
+++ b/src/components/Upload/SingleImage.vue
@@ -58,7 +58,6 @@ export default {
       this.emitInput(this.tempUrl)
     },
     beforeUpload() {
-      const _self = this
       return new Promise((resolve, reject) => {
         // getToken().then(response => {
         //   const key = response.data.qiniu_key

--- a/src/components/Upload/SingleImage2.vue
+++ b/src/components/Upload/SingleImage2.vue
@@ -58,7 +58,6 @@ export default {
       this.emitInput(this.tempUrl)
     },
     beforeUpload() {
-      const _self = this
       return new Promise((resolve, reject) => {
         // getToken().then(response => {
         //   const key = response.data.qiniu_key

--- a/src/components/Upload/SingleImage3.vue
+++ b/src/components/Upload/SingleImage3.vue
@@ -66,7 +66,6 @@ export default {
       this.emitInput(file.files.file)
     },
     beforeUpload() {
-      const _self = this
       // return new Promise((resolve, reject) => {
       //   getToken().then(response => {
       //     const key = response.data.qiniu_key

--- a/src/directive/el-drag-dialog/index.js
+++ b/src/directive/el-drag-dialog/index.js
@@ -1,7 +1,7 @@
 import drag from './drag'
 
-const install = function(Vue) {
-  Vue.directive('el-drag-dialog', drag)
+const install = function(app) {
+  app.directive('el-drag-dialog', drag)
 }
 
 if (window.Vue) {

--- a/src/directive/el-table/index.js
+++ b/src/directive/el-table/index.js
@@ -1,7 +1,7 @@
 import adaptive from './adaptive'
 
-const install = function(Vue) {
-  Vue.directive('el-height-adaptive-table', adaptive)
+const install = function(app) {
+  app.directive('el-height-adaptive-table', adaptive)
 }
 
 if (window.Vue) {

--- a/src/directive/permission/index.js
+++ b/src/directive/permission/index.js
@@ -1,9 +1,9 @@
 import permission from './permission'
 import permisaction from './permisaction'
 
-const install = function(Vue) {
-  Vue.directive('permission', permission)
-  Vue.directive('permisaction', permisaction)
+const install = function(app) {
+  app.directive('permission', permission)
+  app.directive('permisaction', permisaction)
 }
 
 if (window.Vue) {

--- a/src/directive/waves/index.js
+++ b/src/directive/waves/index.js
@@ -1,7 +1,7 @@
 import waves from './waves'
 
-const install = function(Vue) {
-  Vue.directive('waves', waves)
+const install = function(app) {
+  app.directive('waves', waves)
 }
 
 if (window.Vue) {

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,9 +1,10 @@
-import Vue from 'vue'
 import SvgIcon from '@/components/SvgIcon'// svg component
 
-// register globally
-Vue.component('svg-icon', SvgIcon)
+export default {
+  install(app) {
+    app.component('svg-icon', SvgIcon)
 
-const req = require.context('./svg', false, /\.svg$/)
-const requireAll = requireContext => requireContext.keys().map(requireContext)
-requireAll(req)
+    const req = require.context('./svg', false, /\.svg$/)
+    req.keys().forEach(req)
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 
 import Cookies from 'js-cookie'
 
 import 'normalize.css/normalize.css' // a modern alternative to CSS resets
 
-import Element from 'element-ui'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
 import './styles/element-variables.scss'
 
 import '@/styles/index.scss' // global css
@@ -12,7 +13,6 @@ import '@/styles/admin.scss'
 
 import VueCodemirror from 'vue-codemirror'
 import 'codemirror/lib/codemirror.css'
-Vue.use(VueCodemirror)
 
 import App from './App'
 import store from './store'
@@ -24,12 +24,11 @@ import { getItems, setItems } from '@/api/table'
 import { getConfigKey } from '@/api/admin/sys-config'
 import { parseTime, resetForm, addDateRange, selectDictLabel, /* download,*/ selectItemsLabel } from '@/utils/costum'
 
-import './icons' // icon
+import Icons from './icons' // icon
 import './permission' // permission control
-import './utils/error-log' // error log
+import ErrorLog from './utils/error-log' // error log
 
 import Viser from 'viser-vue'
-Vue.use(Viser)
 
 import * as filters from './filters' // global filters
 
@@ -37,46 +36,45 @@ import Pagination from '@/components/Pagination'
 import BasicLayout from '@/layout/BasicLayout'
 
 import VueParticles from 'vue-particles'
-Vue.use(VueParticles)
 
 import '@/utils/dialog'
 
-// 全局方法挂载
-Vue.prototype.getDicts = getDicts
-Vue.prototype.getItems = getItems
-Vue.prototype.setItems = setItems
-Vue.prototype.getConfigKey = getConfigKey
-Vue.prototype.parseTime = parseTime
-Vue.prototype.resetForm = resetForm
-Vue.prototype.addDateRange = addDateRange
-Vue.prototype.selectDictLabel = selectDictLabel
-Vue.prototype.selectItemsLabel = selectItemsLabel
-// Vue.prototype.download = download
+// 全局方法
+const app = createApp(App)
+app.config.globalProperties.getDicts = getDicts
+app.config.globalProperties.getItems = getItems
+app.config.globalProperties.setItems = setItems
+app.config.globalProperties.getConfigKey = getConfigKey
+app.config.globalProperties.parseTime = parseTime
+app.config.globalProperties.resetForm = resetForm
+app.config.globalProperties.addDateRange = addDateRange
+app.config.globalProperties.selectDictLabel = selectDictLabel
+app.config.globalProperties.selectItemsLabel = selectItemsLabel
 
-// 全局组件挂载
-Vue.component('Pagination', Pagination)
-Vue.component('BasicLayout', BasicLayout)
+// 全局组件
+app.component('Pagination', Pagination)
+app.component('BasicLayout', BasicLayout)
 
-Vue.prototype.msgSuccess = function(msg) {
+app.config.globalProperties.msgSuccess = function(msg) {
   this.$message({ showClose: true, message: msg, type: 'success' })
 }
 
-Vue.prototype.msgError = function(msg) {
+app.config.globalProperties.msgError = function(msg) {
   this.$message({ showClose: true, message: msg, type: 'error' })
 }
 
-Vue.prototype.msgInfo = function(msg) {
+app.config.globalProperties.msgInfo = function(msg) {
   this.$message.info(msg)
 }
 
-Vue.use(permission)
+app.use(permission)
 
-Vue.use(Element, {
-  size: Cookies.get('size') || 'medium' // set element-ui default size
+app.use(ElementPlus, {
+  size: Cookies.get('size') || 'medium'
 })
 
 import VueDND from 'awe-dnd'
-Vue.use(VueDND)
+app.use(VueDND)
 
 import 'remixicon/fonts/remixicon.css'
 
@@ -87,14 +85,17 @@ console.info(`欢迎使用go-admin，谢谢您对我们的支持，在使用过�
 
 // register global utility filters
 Object.keys(filters).forEach(key => {
-  Vue.filter(key, filters[key])
+  app.config.globalProperties[key] = filters[key]
 })
 
-Vue.config.productionTip = false
+app.config.productionTip = false
 
-new Vue({
-  el: '#app',
-  router,
-  store,
-  render: h => h(App)
-})
+app
+  .use(Viser)
+  .use(VueCodemirror)
+  .use(VueParticles)
+  .use(Icons)
+  .use(ErrorLog)
+  .use(router)
+  .use(store)
+  .mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,4 @@
-import Vue from 'vue'
-import Router from 'vue-router'
-
-Vue.use(Router)
+import { createRouter, createWebHistory } from 'vue-router'
 
 /* Layout */
 import Layout from '@/layout'
@@ -107,17 +104,18 @@ export const asyncRoutes = [
 
 ]
 
-const createRouter = () => new Router({
-  mode: 'history', // require service support
-  scrollBehavior: () => ({ y: 0 }),
-  routes: constantRoutes
-})
+const createRouterInstance = () =>
+  createRouter({
+    history: createWebHistory(),
+    scrollBehavior: () => ({ y: 0 }),
+    routes: constantRoutes
+  })
 
-const router = createRouter()
+const router = createRouterInstance()
 
 // Detail see: https://github.com/vuejs/vue-router/issues/1234#issuecomment-357941465
 export function resetRouter() {
-  const newRouter = createRouter()
+  const newRouter = createRouterInstance()
   router.matcher = newRouter.matcher // reset router
 }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,8 +1,5 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
+import { createStore } from 'vuex'
 import getters from './getters'
-
-Vue.use(Vuex)
 
 // https://webpack.js.org/guides/dependency-management/#requirecontext
 const modulesFiles = require.context('./modules', true, /\.js$/)
@@ -17,7 +14,7 @@ const modules = modulesFiles.keys().reduce((modules, modulePath) => {
   return modules
 }, {})
 
-const store = new Vuex.Store({
+const store = createStore({
   modules,
   getters
 })

--- a/src/utils/error-log.js
+++ b/src/utils/error-log.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import store from '@/store'
 import { isString, isArray } from '@/utils/validate'
 import settings from '@/settings'
@@ -18,18 +17,21 @@ function checkNeed() {
   return false
 }
 
-if (checkNeed()) {
-  Vue.config.errorHandler = function(err, vm, info, a) {
-  // Don't ask me why I use Vue.nextTick, it just a hack.
-  // detail see https://forum.vuejs.org/t/dispatch-in-vue-config-errorhandler-has-some-problem/23500
-    Vue.nextTick(() => {
-      store.dispatch('errorLog/addErrorLog', {
-        err,
-        vm,
-        info,
-        url: window.location.href
-      })
-      console.error(err, info)
-    })
+export default {
+  install(app) {
+    if (checkNeed()) {
+      app.config.errorHandler = function(err, vm, info) {
+        app.config.errorHandler = null
+        Promise.resolve().then(() => {
+          store.dispatch('errorLog/addErrorLog', {
+            err,
+            vm,
+            info,
+            url: window.location.href
+          })
+          console.error(err, info)
+        })
+      }
+    }
   }
 }

--- a/src/utils/eventbus.js
+++ b/src/utils/eventbus.js
@@ -1,2 +1,4 @@
-import Vue from 'vue'
-export default new Vue()
+import mitt from 'mitt'
+
+const emitter = mitt()
+export default emitter

--- a/src/views/dev-tools/gen/index.vue
+++ b/src/views/dev-tools/gen/index.vue
@@ -124,16 +124,13 @@
                   icon="el-icon-view"
                   @click="handleToDB(scope.row)"
                 >生成配置</el-button>
-
-     
                 <el-button
                   slot="reference"
                   type="text"
                   size="small"
                   icon="el-icon-view"
-                   @click="handleToApiFile(scope.row)"
+                  @click="handleToApiFile(scope.row)"
                 >生成迁移脚本</el-button>
-                
                 <el-button
                   slot="reference"
                   type="text"


### PR DESCRIPTION
## Summary
- start migration to Vue 3
- switch to Element Plus and update Vue Router/Vuex
- adjust main entry and plugins for Vue 3 compatibility
- add mitt based event bus

## Testing
- `npm run lint`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build:stage` *(fails: element-plus module not found)*