### PR TITLE
Fix unit tests

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,9 +12,6 @@ export function parseTime(time, cFormat) {
   if (arguments.length === 0) {
     return null
   }
-  if (time_str.indexOf('01-01-01') > -1) {
-    return '-'
-  }
   const format = cFormat || '{y}-{m}-{d} {h}:{i}:{s}'
   let date
   if (typeof time === 'object') {
@@ -43,6 +40,13 @@ export function parseTime(time, cFormat) {
     if (key === 'a') { return ['日', '一', '二', '三', '四', '五', '六'][value] }
     return value.toString().padStart(2, '0')
   })
+
+  // If `time` is invalid, the formatted string becomes `01-01-01`.
+  // This check was previously before `time_str` existed, causing a reference
+  // error during linting and tests. Moved here to avoid that issue.
+  if (time_str.indexOf('01-01-01') > -1) {
+    return '-'
+  }
 
   return time_str
 }

--- a/tests/unit/components/Hamburger.spec.js
+++ b/tests/unit/components/Hamburger.spec.js
@@ -8,11 +8,12 @@ describe('Hamburger.vue', () => {
     wrapper.find('.hamburger').trigger('click')
     expect(mockFn).toBeCalled()
   })
-  it('prop isActive', () => {
+  // setProps() is async, otherwise DOM updates may not complete before checks
+  it('prop isActive', async() => {
     const wrapper = shallowMount(Hamburger)
-    wrapper.setProps({ isActive: true })
+    await wrapper.setProps({ isActive: true })
     expect(wrapper.contains('.is-active')).toBe(true)
-    wrapper.setProps({ isActive: false })
+    await wrapper.setProps({ isActive: false })
     expect(wrapper.contains('.is-active')).toBe(false)
   })
 })

--- a/tests/unit/components/SvgIcon.spec.js
+++ b/tests/unit/components/SvgIcon.spec.js
@@ -9,14 +9,15 @@ describe('SvgIcon.vue', () => {
     })
     expect(wrapper.find('use').attributes().href).toBe('#icon-test')
   })
-  it('className', () => {
+  // setProps() is async, otherwise class updates won't be observed
+  it('className', async() => {
     const wrapper = shallowMount(SvgIcon, {
       propsData: {
         iconClass: 'test'
       }
     })
     expect(wrapper.classes().length).toBe(1)
-    wrapper.setProps({ className: 'test' })
+    await wrapper.setProps({ className: 'test' })
     expect(wrapper.classes().includes('test')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- fix `parseTime` implementation
- update component tests to await `setProps`
- add explanatory comments

## Testing
- `node node_modules/.pnpm/jest-cli@24.9.0/node_modules/jest-cli/bin/jest.js --clearCache && node node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit`