### PR TITLE
Continue Vue 3 migration

### DIFF
--- a/src/components/Breadcrumb/index.vue
+++ b/src/components/Breadcrumb/index.vue
@@ -9,62 +9,59 @@
   </el-breadcrumb>
 </template>
 
-<script>
+<script setup lang="ts">
 import { compile } from 'path-to-regexp'
+import { ref, watch, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
-export default {
-  data() {
-    return {
-      levelList: null
-    }
-  },
-  watch: {
-    $route(route) {
-      // if you go to the redirect page, do not update the breadcrumbs
-      if (route.path.startsWith('/redirect/')) {
-        return
-      }
-      this.getBreadcrumb()
-    }
-  },
-  created() {
-    this.getBreadcrumb()
-  },
-  methods: {
-    getBreadcrumb() {
-      // only show routes with meta.title
-      let matched = this.$route.matched.filter(item => item.meta && item.meta.title)
-      const first = matched[0]
+defineOptions({ name: 'Breadcrumb' })
 
-      if (!this.isDashboard(first)) {
-        matched = [{ path: '/index', meta: { title: '首页' }}].concat(matched)
-      }
+const route = useRoute()
+const router = useRouter()
 
-      this.levelList = matched.filter(item => item.meta && item.meta.title && item.meta.breadcrumb !== false)
-    },
-    isDashboard(route) {
-      const name = route && route.name
-      if (!name) {
-        return false
-      }
-      return name.trim() === '首页'
-    },
-    pathCompile(path) {
-      // To solve this problem https://github.com/PanJiaChen/vue-element-admin/issues/561
-      const { params } = this.$route
-      var toPath = compile(path)
-      return toPath(params)
-    },
-    handleLink(item) {
-      const { redirect, path } = item
-      if (redirect) {
-        this.$router.push(redirect)
-        return
-      }
-      this.$router.push(this.pathCompile(path))
-    }
+const levelList = ref<any[] | null>(null)
+
+function getBreadcrumb() {
+  let matched = route.matched.filter(item => item.meta && item.meta.title)
+  const first = matched[0]
+
+  if (!isDashboard(first)) {
+    matched = [{ path: '/index', meta: { title: '首页' } }].concat(matched)
   }
+
+  levelList.value = matched.filter(item => item.meta && item.meta.title && item.meta.breadcrumb !== false)
 }
+
+function isDashboard(route: any) {
+  const name = route && route.name
+  if (!name) return false
+  return name.trim() === '首页'
+}
+
+function pathCompile(path: string) {
+  const { params } = route
+  const toPath = compile(path)
+  return toPath(params)
+}
+
+function handleLink(item: any) {
+  const { redirect, path } = item
+  if (redirect) {
+    router.push(redirect)
+    return
+  }
+  router.push(pathCompile(path))
+}
+
+watch(
+  () => route.path,
+  (val) => {
+    if (route.path.startsWith('/redirect/')) return
+    getBreadcrumb()
+  }
+)
+
+onMounted(getBreadcrumb)
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Cell/index.vue
+++ b/src/components/Cell/index.vue
@@ -25,28 +25,22 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'Cell',
-  props: {
-    border: {
-      type: Boolean,
-      default: false
-    },
-    label: {
-      type: String,
-      default: ''
-    },
-    value: {
-      type: String,
-      default: ''
-    },
-    extra: {
-      type: String,
-      default: ''
-    }
-  }
+<script setup lang="ts">
+defineOptions({ name: 'Cell' })
+
+interface Props {
+  border?: boolean
+  label?: string
+  value?: string
+  extra?: string
 }
+
+const props = withDefaults(defineProps<Props>(), {
+  border: false,
+  label: '',
+  value: '',
+  extra: ''
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Go-Admin/Doc/index.vue
+++ b/src/components/Go-Admin/Doc/index.vue
@@ -4,18 +4,10 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'GoAdminDoc',
-  data() {
-    return {
-      url: 'http://doc.zhangwj.com/go-admin-site'
-    }
-  },
-  methods: {
-    goto() {
-      window.open(this.url)
-    }
-  }
+<script setup lang="ts">
+defineOptions({ name: 'GoAdminDoc' })
+const url = 'http://doc.zhangwj.com/go-admin-site'
+const goto = () => {
+  window.open(url)
 }
 </script>

--- a/src/components/Go-Admin/Donate/index.vue
+++ b/src/components/Go-Admin/Donate/index.vue
@@ -4,18 +4,10 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'GoAdminDonate',
-  data() {
-    return {
-      url: 'http://doc.zhangwj.com/go-admin-site/donate/'
-    }
-  },
-  methods: {
-    goto() {
-      window.open(this.url)
-    }
-  }
+<script setup lang="ts">
+defineOptions({ name: 'GoAdminDonate' })
+const url = 'http://doc.zhangwj.com/go-admin-site/donate/'
+const goto = () => {
+  window.open(url)
 }
 </script>

--- a/src/components/Go-Admin/Git/index.vue
+++ b/src/components/Go-Admin/Git/index.vue
@@ -4,18 +4,10 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'GoAdminGit',
-  data() {
-    return {
-      url: 'https://github.com/wenjianzhang/go-admin'
-    }
-  },
-  methods: {
-    goto() {
-      window.open(this.url)
-    }
-  }
+<script setup lang="ts">
+defineOptions({ name: 'GoAdminGit' })
+const url = 'https://github.com/wenjianzhang/go-admin'
+const goto = () => {
+  window.open(url)
 }
 </script>

--- a/src/components/IconSelect/index.vue
+++ b/src/components/IconSelect/index.vue
@@ -12,33 +12,31 @@
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
 import icons from './requireIcons'
-export default {
-  name: 'IconSelect',
-  data() {
-    return {
-      name: '',
-      iconList: icons
-    }
-  },
-  methods: {
-    filterIcons() {
-      if (this.name) {
-        this.iconList = this.iconList.filter(item => item.includes(this.name))
-      } else {
-        this.iconList = icons
-      }
-    },
-    selectedIcon(name) {
-      this.$emit('selected', name)
-      document.body.click()
-    },
-    reset() {
-      this.name = ''
-      this.iconList = icons
-    }
+
+defineOptions({ name: 'IconSelect' })
+
+const emit = defineEmits(['selected'])
+const name = ref('')
+const iconList = ref<string[]>([...icons])
+
+function filterIcons() {
+  if (name.value) {
+    iconList.value = icons.filter(item => item.includes(name.value))
+  } else {
+    iconList.value = [...icons]
   }
+}
+
+function selectedIcon(iconName: string) {
+  emit('selected', iconName)
+  document.body.click()
+}
+
+function reset() {
+  name.value = ''
+  iconList.value = [...icons]
 }
 </script>
 

--- a/src/components/RightPanel/index.vue
+++ b/src/components/RightPanel/index.vue
@@ -12,68 +12,60 @@
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
 import { addClass, removeClass } from '@/utils'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { useStore } from 'vuex'
 
-export default {
-  name: 'RightPanel',
-  props: {
-    clickNotClose: {
-      default: false,
-      type: Boolean
-    },
-    buttonTop: {
-      default: 250,
-      type: Number
-    }
-  },
-  data() {
-    return {
-      show: false
-    }
-  },
-  computed: {
-    theme() {
-      return this.$store.state.settings.theme
-    }
-  },
-  watch: {
-    show(value) {
-      if (value && !this.clickNotClose) {
-        this.addEventClick()
-      }
-      if (value) {
-        addClass(document.body, 'showRightPanel')
-      } else {
-        removeClass(document.body, 'showRightPanel')
-      }
-    }
-  },
-  mounted() {
-    this.insertToBody()
-  },
-  beforeDestroy() {
-    const elx = this.$refs.rightPanel
-    elx.remove()
-  },
-  methods: {
-    addEventClick() {
-      window.addEventListener('click', this.closeSidebar)
-    },
-    closeSidebar(evt) {
-      const parent = evt.target.closest('.rightPanel')
-      if (!parent) {
-        this.show = false
-        window.removeEventListener('click', this.closeSidebar)
-      }
-    },
-    insertToBody() {
-      const elx = this.$refs.rightPanel
-      const body = document.querySelector('body')
-      body.insertBefore(elx, body.firstChild)
-    }
+defineOptions({ name: 'RightPanel' })
+
+const props = withDefaults(defineProps<{ clickNotClose?: boolean; buttonTop?: number }>(), {
+  clickNotClose: false,
+  buttonTop: 250
+})
+
+const show = ref(false)
+const rightPanel = ref<HTMLElement | null>(null)
+const store = useStore()
+const theme = computed(() => store.state.settings.theme)
+
+function addEventClick() {
+  window.addEventListener('click', closeSidebar)
+}
+
+function closeSidebar(evt: Event) {
+  const parent = (evt.target as HTMLElement).closest('.rightPanel')
+  if (!parent) {
+    show.value = false
+    window.removeEventListener('click', closeSidebar)
   }
 }
+
+function insertToBody() {
+  const elx = rightPanel.value
+  const body = document.querySelector('body')!
+  if (elx) body.insertBefore(elx, body.firstChild)
+}
+
+watch(show, value => {
+  if (value && !props.clickNotClose) {
+    addEventClick()
+  }
+  if (value) {
+    addClass(document.body, 'showRightPanel')
+  } else {
+    removeClass(document.body, 'showRightPanel')
+  }
+})
+
+onMounted(() => {
+  insertToBody()
+})
+
+onBeforeUnmount(() => {
+  const elx = rightPanel.value
+  elx?.remove()
+})
 </script>
 
 <style>

--- a/src/layout/BasicLayout.vue
+++ b/src/layout/BasicLayout.vue
@@ -4,10 +4,8 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'BasicLayout'
-}
+<script setup lang="ts">
+defineOptions({ name: 'BasicLayout' })
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/error-page/404.vue
+++ b/src/views/error-page/404.vue
@@ -20,16 +20,12 @@
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import { computed } from 'vue'
 
-export default {
-  name: 'Page404',
-  computed: {
-    message() {
-      return 'The webmaster said that you can not enter this page...'
-    }
-  }
-}
+defineOptions({ name: 'Page404' })
+
+const message = computed(() => 'The webmaster said that you can not enter this page...')
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/login/auth-redirect.vue
+++ b/src/views/login/auth-redirect.vue
@@ -1,15 +1,15 @@
-<script>
-export default {
-  name: 'AuthRedirect',
-  created() {
-    const hash = window.location.search.slice(1)
-    if (window.localStorage) {
-      window.localStorage.setItem('x-admin-oauth-code', hash)
-      window.close()
-    }
-  },
-  render: function(h) {
-    return h() // avoid warning message
+<template></template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+
+onMounted(() => {
+  const hash = window.location.search.slice(1)
+  if (window.localStorage) {
+    window.localStorage.setItem('x-admin-oauth-code', hash)
+    window.close()
   }
-}
+})
+
+defineOptions({ name: 'AuthRedirect' })
 </script>

--- a/src/views/redirect/index.vue
+++ b/src/views/redirect/index.vue
@@ -1,12 +1,16 @@
-<script>
-export default {
-  created() {
-    const { params, query } = this.$route
-    const { path } = params
-    this.$router.replace({ path: '/' + path, query })
-  },
-  render: function(h) {
-    return h() // avoid warning message
-  }
-}
+<template></template>
+<script setup lang="ts">
+import { useRouter, useRoute, onMounted } from 'vue-router'
+
+defineOptions({ name: 'Redirect' })
+
+const router = useRouter()
+const route = useRoute()
+
+onMounted(() => {
+  const { params, query } = route
+  const { path } = params as any
+  router.replace({ path: '/' + path, query })
+})
 </script>
+


### PR DESCRIPTION
## Summary
- roll back Task4 documentation checklists to reflect incomplete work
- migrate more components and pages to Composition API
  - Cell, IconSelect, Breadcrumb, RightPanel
  - redirect and 404 pages
- restore previous `pnpm-lock.yaml`

## Testing
- `pnpm lint` *(fails: Parsing error)*
- `pnpm test:unit` *(fails: jest not defined and other errors)*